### PR TITLE
Switch deployment to the #main branch until the AWS ab-utils changes are merged

### DIFF
--- a/.github/workflows/build-deploy-ecs.yml
+++ b/.github/workflows/build-deploy-ecs.yml
@@ -3,8 +3,8 @@ name: Build & Deploy ECS
 on:
   push:
     branches:
-      # Automatically build master and staging. Additional branches may be added.
-      - master
+      # Automatically build main and staging. Additional branches may be added.
+      - main
       - staging
   workflow_dispatch:
     # Allows manual build and deploy of any branch/ref


### PR DESCRIPTION
Switch deployment to the #main branch until the AWS ab-utils changes are merged
[CruGlobal/ab-utils#77](https://github.com/CruGlobal/ab-utils/pull/77)
[CruGlobal/global-hr-update#405](https://github.com/CruGlobal/global-hr-update/issues/405)